### PR TITLE
Use JWT for token handling and add endpoint tests

### DIFF
--- a/controllers/controllers_test.go
+++ b/controllers/controllers_test.go
@@ -1,0 +1,28 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"RaiJaiAPI_Golang/database"
+	"RaiJaiAPI_Golang/models"
+	"RaiJaiAPI_Golang/routes"
+)
+
+func setupTestRouter(t *testing.T) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open test database: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.Type{}, &models.Category{}, &models.Transaction{}, &models.Book{}); err != nil {
+		t.Fatalf("failed to migrate: %v", err)
+	}
+	database.DB = db
+	r := gin.Default()
+	routes.SetupRoutes(r)
+	return r
+}

--- a/controllers/transaction_controller_test.go
+++ b/controllers/transaction_controller_test.go
@@ -1,0 +1,64 @@
+package controllers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"RaiJaiAPI_Golang/database"
+	"RaiJaiAPI_Golang/models"
+	"RaiJaiAPI_Golang/utils"
+)
+
+func TestCreateAndListTransactions(t *testing.T) {
+	os.Setenv("JWT_SECRET", "testsecret")
+	r := setupTestRouter(t)
+
+	user := models.User{Name: "Bob", Email: "bob@example.com", Password: "pass"}
+	if err := database.DB.Create(&user).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	ttype := models.Type{Name: "expense"}
+	database.DB.Create(&ttype)
+	category := models.Category{Name: "food", TypeID: ttype.ID, UserID: user.ID}
+	database.DB.Create(&category)
+	book := models.Book{Title: "wallet"}
+	database.DB.Create(&book)
+
+	token, _ := utils.GenerateToken(user.ID)
+
+	payload := fmt.Sprintf(`{"amount":100,"note":"lunch","date":"%s","user_id":%d,"book_id":%d,"category_id":%d}`,
+		time.Now().Format(time.RFC3339), user.ID, book.ID, category.ID)
+	req := httptest.NewRequest("POST", "/api/transactions/", bytes.NewBufferString(payload))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201 got %d", w.Code)
+	}
+
+	req = httptest.NewRequest("GET", "/api/transactions/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", w.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("expected success")
+	}
+	data, ok := body["data"].([]interface{})
+	if !ok || len(data) != 1 {
+		t.Fatalf("expected 1 transaction got %v", body["data"])
+	}
+}

--- a/controllers/user_controller_test.go
+++ b/controllers/user_controller_test.go
@@ -1,0 +1,38 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"RaiJaiAPI_Golang/database"
+	"RaiJaiAPI_Golang/models"
+	"RaiJaiAPI_Golang/utils"
+)
+
+func TestGetUsers(t *testing.T) {
+	os.Setenv("JWT_SECRET", "testsecret")
+	r := setupTestRouter(t)
+	u := models.User{Name: "Alice", Email: "alice@example.com", Password: "pass"}
+	if err := database.DB.Create(&u).Error; err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	token, _ := utils.GenerateToken(u.ID)
+
+	req := httptest.NewRequest("GET", "/api/users/", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 got %d", w.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if body["success"] != true {
+		t.Fatalf("expected success")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,11 @@ module RaiJaiAPI_Golang
 
 go 1.24.4
 
-require github.com/stretchr/testify v1.10.0
+require (
+        github.com/golang-jwt/jwt/v5 v5.0.0
+        github.com/stretchr/testify v1.10.0
+        gorm.io/driver/sqlite v1.5.7
+)
 
 require (
 	github.com/KyleBanks/depth v1.2.1 // indirect

--- a/utils/token.go
+++ b/utils/token.go
@@ -1,15 +1,11 @@
 package utils
 
 import (
-	"crypto/hmac"
-	"crypto/sha256"
-	"encoding/base64"
 	"errors"
-	"fmt"
 	"os"
-	"strconv"
-	"strings"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func secretKey() string {
@@ -21,46 +17,34 @@ func secretKey() string {
 }
 
 func GenerateToken(uid uint) (string, error) {
-	expiry := time.Now().Add(24 * time.Hour).Unix()
-	payload := fmt.Sprintf("%d:%d", uid, expiry)
-	enc := base64.StdEncoding.EncodeToString([]byte(payload))
-	sig := computeHMAC(enc, secretKey())
-	return fmt.Sprintf("%s.%s", enc, sig), nil
+	claims := jwt.MapClaims{
+		"uid": uid,
+		"exp": time.Now().Add(24 * time.Hour).Unix(),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(secretKey()))
 }
 
 func ValidateToken(token string) (uint, error) {
-	parts := strings.Split(token, ".")
-	if len(parts) != 2 {
-		return 0, errors.New("invalid token")
-	}
-	enc, sig := parts[0], parts[1]
-	if computeHMAC(enc, secretKey()) != sig {
-		return 0, errors.New("invalid token")
-	}
-	data, err := base64.StdEncoding.DecodeString(enc)
+	claims := jwt.MapClaims{}
+	parsed, err := jwt.ParseWithClaims(token, claims, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("invalid token")
+		}
+		return []byte(secretKey()), nil
+	})
 	if err != nil {
+		if errors.Is(err, jwt.ErrTokenExpired) {
+			return 0, errors.New("token expired")
+		}
 		return 0, errors.New("invalid token")
 	}
-	p := strings.Split(string(data), ":")
-	if len(p) != 2 {
+	if !parsed.Valid {
 		return 0, errors.New("invalid token")
 	}
-	id, err := strconv.ParseUint(p[0], 10, 64)
-	if err != nil {
-		return 0, err
+	uid, ok := claims["uid"].(float64)
+	if !ok {
+		return 0, errors.New("invalid token")
 	}
-	exp, err := strconv.ParseInt(p[1], 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	if time.Now().Unix() > exp {
-		return 0, errors.New("token expired")
-	}
-	return uint(id), nil
-}
-
-func computeHMAC(data, secret string) string {
-	h := hmac.New(sha256.New, []byte(secret))
-	h.Write([]byte(data))
-	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+	return uint(uid), nil
 }

--- a/utils/token_test.go
+++ b/utils/token_test.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestGenerateAndValidateToken(t *testing.T) {
+	os.Setenv("JWT_SECRET", "testsecret")
+	token, err := GenerateToken(42)
+	if err != nil {
+		t.Fatalf("generate token error: %v", err)
+	}
+	uid, err := ValidateToken(token)
+	if err != nil {
+		t.Fatalf("validate token error: %v", err)
+	}
+	if uid != 42 {
+		t.Fatalf("expected 42 got %d", uid)
+	}
+}
+
+func TestValidateTokenInvalidSignature(t *testing.T) {
+	os.Setenv("JWT_SECRET", "testsecret")
+	token, _ := GenerateToken(1)
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 {
+		t.Fatalf("unexpected token format")
+	}
+	parts[2] = "tampered"
+	if _, err := ValidateToken(strings.Join(parts, ".")); err == nil {
+		t.Fatalf("expected error for invalid signature")
+	}
+}
+
+func TestValidateTokenExpired(t *testing.T) {
+	os.Setenv("JWT_SECRET", "testsecret")
+	claims := jwt.MapClaims{
+		"uid": 1,
+		"exp": time.Now().Add(-time.Hour).Unix(),
+	}
+	expired := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	token, _ := expired.SignedString([]byte(secretKey()))
+	if _, err := ValidateToken(token); err == nil || err.Error() != "token expired" {
+		t.Fatalf("expected token expired error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- replace custom token logic with standard JWT-based generation and validation
- add tests for tokens, user listing, and transaction creation
- include jwt and sqlite dependencies for testing

## Testing
- `go mod tidy` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: missing go.sum entry for github.com/golang-jwt/jwt/v5)*

------
https://chatgpt.com/codex/tasks/task_e_68976b60237c832292c33cf4375ec9f3